### PR TITLE
Add Label model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chipster-js-common",
-  "version": "1.5.9",
+  "version": "1.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chipster-js-common",
-      "version": "1.5.9",
+      "version": "1.5.11",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipster-js-common",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "type": "module",
   "private": false,
   "main": "lib/index.js",

--- a/src/events/wsevent.ts
+++ b/src/events/wsevent.ts
@@ -8,6 +8,7 @@ export const enum Resource {
   Session = "SESSION",
   Rule = "RULE",
   News = "NEWS",
+  Label = "LABEL",
 }
 
 export const enum EventType {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { default as Rule } from "./model/rule.js";
 export { default as Share } from "./model/share.js";
 export { default as Service } from "./model/service.js";
 export { default as Session, SessionState } from "./model/session.js";
+export { default as Label } from "./model/label.js";
 export { default as Token } from "./model/token.js";
 export { default as Tool } from "./model/tool.js";
 export { default as ToolInput } from "./model/toolinput.js";

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -19,6 +19,7 @@ export default class Dataset {
   name: string;
   notes: string;
   metadataFiles: MetadataFile[];
+  labelIds: string[];
   size: number;
   sourceJob: string;
   x: number;

--- a/src/model/label.ts
+++ b/src/model/label.ts
@@ -1,0 +1,7 @@
+export default class Label {
+  sessionId: string;
+  labelId: string;
+  name: string;
+  color: string;
+  created: string;
+}


### PR DESCRIPTION
## Summary

- Add `Label` model class (`sessionId`, `labelId`, `name`, `color`, `created`) at `src/model/label.ts`, mirroring the backend's flat JSON shape (`@JsonUnwrapped LabelIdPair`).
- Add `labelIds: string[]` to `Dataset` so datasets can carry label associations.
- Add `Resource.Label = \"LABEL\"` to the `WsEvent` enum so WebSocket events can announce label CRUD.
- Barrel-export `Label` from `src/index.ts`.

## Versioning

Patch bump 1.5.10 → 1.5.11. Also brings `package-lock.json` (previously stale at 1.5.9) back in sync.

## Test plan

- [ ] \`tsc\` builds cleanly: \`npm install && npm run prepare\`
- [ ] Consumers (\`chipster-web\`, server type-service) compile against the new types without errors